### PR TITLE
Refactor variable and function names in motor_controller

### DIFF
--- a/motor_controller/inc/coms.h
+++ b/motor_controller/inc/coms.h
@@ -2,7 +2,7 @@
 #define COMS_H_
 #include "canard.h"
 
-void comInit(void);
+void coms_init(void);
 void updateComs(void);
 
 /* ------------ Error Definitions --------------- */
@@ -75,6 +75,6 @@ int16_t setup_hardware_can_filters(void);
 
 void coms_handle_forever(void);
 
-void publish_nodeStatus(void);
+void publish_NodeStatus(void);
 
 #endif

--- a/motor_controller/inc/encoders.h
+++ b/motor_controller/inc/encoders.h
@@ -27,7 +27,7 @@ typedef enum {
 } encoder_type_t;
 
 void encoder_init(void);
-int32_t encoder_read(void);
-int32_t encoder_get_position(float in_angle);
+int32_t encoder_read_observation(void);
+int32_t encoder_get_target_observation(float command_angle);
 
 #endif

--- a/motor_controller/inc/main.h
+++ b/motor_controller/inc/main.h
@@ -42,7 +42,7 @@
 /** Period of motor control loop */
 #define MOTOR_CONTROL_PERIOD 100
 
-extern int32_t desired_positions[2];
+extern int32_t target_observations[2];
 extern arm_pid_instance_f32 pid;
 
 extern bool flag_motor_running;
@@ -50,6 +50,6 @@ extern bool flag_motor_running;
 extern thread_t *RunMotor_thread;
 extern thread_t *Heartbeat_thread;
 
-void motor_set(float position);
+void motor_set(float command_angle);
 
 #endif /* MAIN_H_ */

--- a/motor_controller/inc/settings.h
+++ b/motor_controller/inc/settings.h
@@ -21,17 +21,17 @@ typedef enum {
   SETTING_REAL = UAVCAN_PROTOCOL_PARAM_VALUE_REAL_VALUE,
   SETTING_INTEGER = UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE,
   SETTING_BOOLEAN = UAVCAN_PROTOCOL_PARAM_VALUE_BOOLEAN_VALUE,
-} setting_t;
+} setting_type_t;
 
 /** @brief Structure to hold the relevant information for settings
  */
-struct parameter {
+struct setting_spec_t {
   char* name;
-  setting_t union_tag;
+  setting_type_t union_tag;
 };
 
-struct setting {
-  setting_t union_tag;
+struct setting_value_t {
+  setting_type_t union_tag;
   union {
     double real;
     int64_t integer;
@@ -53,12 +53,12 @@ struct setting {
 
 #define NUM_SETTINGS 18
 
-extern const struct parameter parameter_info[NUM_SETTINGS];
-extern struct setting saved_settings[NUM_SETTINGS];
-extern struct setting current_settings[NUM_SETTINGS];
-extern struct setting run_settings[NUM_SETTINGS];
+extern const struct setting_spec_t setting_specs[NUM_SETTINGS];
+extern struct setting_value_t saved_settings[NUM_SETTINGS];
+extern struct setting_value_t pending_settings[NUM_SETTINGS];
+extern struct setting_value_t current_settings[NUM_SETTINGS];
 
-int8_t get_id_by_name(char* name);
-void handle_getSet(CanardInstance* ins, CanardRxTransfer* transfer);
+int8_t get_setting_index_by_name(char* name);
+void handle_GetSet(CanardInstance* ins, CanardRxTransfer* transfer);
 
 #endif /* SETTINGS_H_ */

--- a/motor_controller/source/settings_parameters.c
+++ b/motor_controller/source/settings_parameters.c
@@ -8,7 +8,7 @@
 #include "settings.h"
 
 // Strings for all the parameters
-const struct parameter parameter_info[NUM_SETTINGS] = {
+const struct setting_spec_t setting_specs[NUM_SETTINGS] = {
     CAN_SETTING_INTEGER("spear.motor.firstboot"),
     CAN_SETTING_BOOLEAN("spear.motor.enabled"),
     CAN_SETTING_INTEGER("spear.motor.actuator_id"),


### PR DESCRIPTION
Renames a lot of variables and functions with the goal of better representing what they are used for. For example, `run_settings` is renamed to `current_settings`, and `current_settings` becomes `pending_settings`. I've also tried to standardize things a bit. For example, canros message names in function names were sometimes in camelCase (e.g. `publish_nodeStatus`) and sometimes in MixedCase (`publish_NodeStatus`). Mixed case is now used throughout.

One downside here is the new variables tend to be a bit more verbose, especially when accessing settings. I think that in the case of editing settings, the correct solution is to write functions to get and set setting values by name rather than accessing the arrays directly. But that's not included in this PR since this PR is limited to renaming.