### PR TITLE
CI Build Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,13 @@
+name: Build Jobs
+on: [pull_request]
+jobs:
+  build-motor-controller:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: fiam/arm-none-eabi-gcc@v1
+        with:
+          release: '9-2020-q2'
+      - run: cd motor_controller && make


### PR DESCRIPTION
Added a github action to build the `motor_controller` on every PR.

When we add more projects we should add them to this (it's pretty trivial).