### PR TITLE
common/Vagrantfile: move to PyPI version of nunavut

### DIFF
--- a/common/Vagrantfile
+++ b/common/Vagrantfile
@@ -99,13 +99,7 @@ Vagrant.configure("2") do |config|
 	export PATH=/usr/local/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH
 	cd /home/vagrant/spear-embedded
 	rm -f gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
-	pip3 install pydsdl
-	git clone https://github.com/davidlenfesty/nunavut
-	cd nunavut
-	git checkout a34b2c31f87ff08bfc2c0d9894533a68f135d59f
-	sudo python3 setup.py install
-	cd ..
-	rm -r nunavut
+	pip3 install pydsdl nunavut
 	sudo apt-get autoremove -y
    SHELL
 end


### PR DESCRIPTION
Noticed this while working on the GH action, my fork is out of date.