### PR TITLE
common: Add libuavcan.cmake

### DIFF
--- a/common/libuavcan.cmake
+++ b/common/libuavcan.cmake
@@ -1,0 +1,26 @@
+set(LIBUAVCAN ${COMMON}/uavcan_dsdl/libuavcan)
+target_compile_definitions(${EXECUTABLE} PRIVATE
+  UAVCAN_STM32_CHIBIOS=1
+  UAVCAN_STM32_NUM_IFACES=1
+  UAVCAN_STM32_TIMER_NUMBER=6
+)
+
+target_include_directories(${EXECUTABLE} PRIVATE
+  ${LIBUAVCAN}/libuavcan/include
+  ${LIBUAVCAN}/libuavcan_drivers/stm32/driver/include
+  ${COMMON}/uavcan_dsdl/libuavcan_dsdlc_generated
+)
+
+FILE(GLOB LIBUAVCAN_SRC
+  ${LIBUAVCAN}/libuavcan/src/*.cpp
+  ${LIBUAVCAN}/libuavcan/src/driver/*.cpp
+  ${LIBUAVCAN}/libuavcan/src/marshal/*.cpp
+  ${LIBUAVCAN}/libuavcan/src/node/*.cpp
+  ${LIBUAVCAN}/libuavcan/src/protocol/*.cpp
+  ${LIBUAVCAN}/libuavcan/src/transport/*.cpp
+  ${LIBUAVCAN}/libuavcan_drivers/stm32/driver/src/*.cpp
+)
+
+target_sources(${EXECUTABLE} PRIVATE
+  ${LIBUAVCAN_SRC}
+)


### PR DESCRIPTION
This should be entirely self contained, and can simply be included in
the main CMakeLists.txt to add libuavcan to the build.